### PR TITLE
检查api调用返回值是否包含“FAILURE”，若包含则抛出异常，以便执行事务“cancel”操作

### DIFF
--- a/src/Tcc.php
+++ b/src/Tcc.php
@@ -42,7 +42,7 @@ class Tcc
             ],
         ]);
         checkStatus($response->getStatusCode());
-        return $client->post($tryUrl, [
+        $response = $client->post($tryUrl, [
             'json' => $body,
             'query' => [
                 'gid' => $this->gid,
@@ -51,5 +51,7 @@ class Tcc
                 'branch_type' => 'try',
             ],
         ]);
+        checkFailure($response->getBody()->read(1024));
+        return $response;
     }
 }

--- a/src/Tcc.php
+++ b/src/Tcc.php
@@ -51,7 +51,7 @@ class Tcc
                 'branch_type' => 'try',
             ],
         ]);
-        checkFailure($response->getBody()->read(1024));
+        checkFailure($response->getBody()->getContents());
         return $response;
     }
 }

--- a/src/functions.php
+++ b/src/functions.php
@@ -28,6 +28,18 @@ namespace Dtmcli {
     }
 
     /**
+     * @param string $str
+     * @param string $errorMsg error message default ''
+     * @throws \Exception
+     */
+    function checkFailure(string $str, string $errorMsg = ''): void
+    {
+        if (stripos($str, 'FAILURE') !== false) {
+            throw new \Exception($errorMsg);
+        }
+    }
+
+    /**
      * @param string $dtmUrl
      * @param callable $cb
      * @return string


### PR DESCRIPTION
检查api调用返回值是否包含“FAILURE”，若包含则抛出异常，以便执行事务“cancel”操作.